### PR TITLE
tests: Add end-to-end test for the examples

### DIFF
--- a/tests/test_examples_e2e.py
+++ b/tests/test_examples_e2e.py
@@ -1,0 +1,232 @@
+# Copyright 2026, the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""End-to-end test that runs the repository, uploader and client examples.
+
+Unlike test_examples.py (which execs the self-contained 'manual_repo'
+scripts), this test wires the three interacting examples together the way
+a user would run them from the command line:
+
+* 'examples/repository/repo' is started as a live HTTP server,
+* 'examples/uploader/uploader' performs Trust-On-First-Use, claims a
+  delegation and uploads target files to that server,
+* 'examples/client/client' performs Trust-On-First-Use and downloads the
+  uploaded targets, which verifies them against the repository metadata.
+
+The test also uploads a second target after the client has already been
+initialized, then downloads it: this exercises the case from issue #2228
+where a client with metadata version N must update to version N+M.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from typing import ClassVar
+from urllib.parse import quote
+
+import urllib3
+
+from tests import utils
+
+# The repository example serves metadata under this URL prefix.
+_METADATA_URL = "metadata"
+
+
+def _get_free_port() -> int:
+    """Return a currently-free localhost TCP port.
+
+    The port is handed to the example repository server via '-p'. There is a
+    small race between closing this socket and the server binding the port,
+    but the readiness poll in setUp() tolerates it.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((utils.TEST_HOST_ADDRESS, 0))
+        return int(sock.getsockname()[1])
+
+
+class TestExamplesEnd2End(unittest.TestCase):
+    """Run the repository, uploader and client examples against each other."""
+
+    examples_dir: ClassVar[Path]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.examples_dir = Path(__file__).resolve().parents[1] / "examples"
+
+    def setUp(self) -> None:
+        # The examples import their private helper modules by name (e.g.
+        # "from _simplerepo import SimpleRepository"), so each example dir
+        # must be importable. The client and uploader also write trusted
+        # metadata and keys under Path.home(): point HOME at a throwaway dir
+        # so the test does not touch the real home directory and starts from
+        # a clean slate every run.
+        self.test_dir = tempfile.mkdtemp()
+        self.addCleanup(self._rmtree, self.test_dir)
+
+        self.env = os.environ.copy()
+        self.env["HOME"] = self.test_dir
+        self.env["PYTHONPATH"] = os.pathsep.join(
+            str(self.examples_dir / name)
+            for name in ("repository", "uploader", "client")
+        )
+
+        self.port = _get_free_port()
+        self.base_url = f"http://{utils.TEST_HOST_ADDRESS}:{self.port}"
+
+        # Start the repository example as a live server subprocess.
+        repo_script = self.examples_dir / "repository" / "repo"
+        self.server = subprocess.Popen(
+            [sys.executable, "-u", str(repo_script), "-p", str(self.port)],
+            env=self.env,
+            cwd=self.test_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        self.addCleanup(self._stop_server)
+
+        utils.wait_for_server(
+            utils.TEST_HOST_ADDRESS, "repository example", self.port
+        )
+        # wait_for_server only confirms the port is open; also wait until the
+        # repository has published its initial root metadata.
+        self._wait_for_root()
+
+    def _rmtree(self, path: str) -> None:
+        # shutil.rmtree wrapper registered with addCleanup.
+        shutil.rmtree(path, ignore_errors=True)
+
+    def _stop_server(self) -> None:
+        self.server.terminate()
+        try:
+            self.server.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.server.kill()
+            self.server.wait()
+        if self.server.stdout is not None:
+            self.server.stdout.close()
+
+    def _wait_for_root(self, timeout: int = 10) -> None:
+        """Poll until the server serves 1.root.json (or time out)."""
+        deadline = time.monotonic() + timeout
+        url = f"{self.base_url}/{_METADATA_URL}/1.root.json"
+        last_error: Exception | None = None
+        while time.monotonic() < deadline:
+            if self.server.poll() is not None:
+                self.fail(
+                    "repository example exited early with code "
+                    f"{self.server.returncode}:\n{self._server_output()}"
+                )
+            try:
+                response = urllib3.request("GET", url)
+                if response.status == 200:
+                    return
+            except urllib3.exceptions.HTTPError as e:
+                last_error = e
+            time.sleep(0.05)
+        self.fail(
+            f"repository example never served root metadata: {last_error}"
+        )
+
+    def _server_output(self) -> str:
+        if self.server.stdout is None:
+            return ""
+        return self.server.stdout.read().decode("utf-8", errors="replace")
+
+    def _run_example(self, script: str, *args: str) -> None:
+        """Run an example script as a subprocess and assert it succeeds."""
+        script_path = self.examples_dir / script
+        result = subprocess.run(
+            [sys.executable, str(script_path), "-u", self.base_url, *args],
+            env=self.env,
+            cwd=self.test_dir,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"{script} {' '.join(args)} failed (rc={result.returncode}):\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    def _snapshot_version(self) -> int:
+        """Return the version of the repository's current snapshot metadata."""
+        url = f"{self.base_url}/{_METADATA_URL}/snapshot.json"
+        response = urllib3.request("GET", url)
+        self.assertEqual(response.status, 200)
+        return int(json.loads(response.data)["signed"]["version"])
+
+    def _downloaded_target(self, targetpath: str) -> bytes:
+        """Read a target the client downloaded into its downloads dir.
+
+        The client writes targets into a 'downloads' dir at its CWD, using the
+        URL-quoted targetpath as filename (see Updater file path generation).
+        """
+        path = Path(self.test_dir) / "downloads" / quote(targetpath, "")
+        self.assertTrue(path.exists(), f"missing downloaded target {path}")
+        return path.read_bytes()
+
+    def test_repository_uploader_client(self) -> None:
+        """Upload targets via the uploader and download them via the client.
+
+        Covers the end-to-end "examples" slice of issue #2228: a client can
+        download a target and can update across metadata versions (N -> N+M).
+        """
+        uploader = "uploader/uploader"
+        client = "client/client"
+        role = "myrole"
+        first_target = f"{role}/first"
+        second_target = f"{role}/second"
+
+        # Maintainer side: trust the repo, claim a delegation, add a target.
+        self._run_example(uploader, "tofu")
+        self._run_example(uploader, "add-delegation", role)
+        self._run_example(uploader, "add-target", role, first_target)
+
+        version_after_first = self._snapshot_version()
+
+        # Client side: trust the repo and download the first target. The
+        # Updater verifies the target against the (signed) repository metadata
+        # before download_target() returns, so a successful download means the
+        # metadata chain and the target hash both verified.
+        self._run_example(client, "tofu")
+        self._run_example(client, "download", first_target)
+
+        # The example generates target content equal to the targetpath.
+        self.assertEqual(
+            self._downloaded_target(first_target),
+            first_target.encode(),
+        )
+
+        # Maintainer adds a second target. This publishes new targets,
+        # snapshot and timestamp metadata, so the repository advances past the
+        # version the client currently trusts.
+        self._run_example(uploader, "add-target", role, second_target)
+        version_after_second = self._snapshot_version()
+        self.assertGreater(version_after_second, version_after_first)
+
+        # Client downloads the second target. download() refreshes metadata
+        # first, so the already-initialized client must update from the
+        # version it trusts (N) to the newer version (N+M) to find and verify
+        # the new target.
+        self._run_example(client, "download", second_target)
+        self.assertEqual(
+            self._downloaded_target(second_target),
+            second_target.encode(),
+        )
+
+
+if __name__ == "__main__":
+    utils.configure_test_logging(sys.argv)
+    unittest.main()

--- a/tests/test_examples_e2e.py
+++ b/tests/test_examples_e2e.py
@@ -41,12 +41,18 @@ from tests import utils
 _METADATA_URL = "metadata"
 
 
+# Number of times to retry starting the server on a fresh port. A retry is
+# only needed if another process grabs the port in the small window between
+# _get_free_port() releasing it and the server binding it, which is rare.
+_MAX_SERVER_STARTS = 5
+
+
 def _get_free_port() -> int:
     """Return a currently-free localhost TCP port.
 
     The port is handed to the example repository server via '-p'. There is a
-    small race between closing this socket and the server binding the port,
-    but the readiness poll in setUp() tolerates it.
+    small race between closing this socket and the server binding the port;
+    _start_server() retries on a fresh port if the server loses that race.
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind((utils.TEST_HOST_ADDRESS, 0))
@@ -57,6 +63,9 @@ class TestExamplesEnd2End(unittest.TestCase):
     """Run the repository, uploader and client examples against each other."""
 
     examples_dir: ClassVar[Path]
+
+    server: subprocess.Popen[bytes]
+    _stopped_output: str | None
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -79,26 +88,57 @@ class TestExamplesEnd2End(unittest.TestCase):
             for name in ("repository", "uploader", "client")
         )
 
-        self.port = _get_free_port()
-        self.base_url = f"http://{utils.TEST_HOST_ADDRESS}:{self.port}"
+        self._stopped_output = None
+        self._start_server()
 
-        # Start the repository example as a live server subprocess.
+    def _start_server(self) -> None:
+        """Start the repository example and wait until it serves metadata.
+
+        The server is started as a subprocess on a free port. If it loses the
+        race for that port (another process binds it first) the subprocess
+        exits with "Address already in use"; in that case we pick a new port
+        and try again rather than reporting a misleading connection timeout.
+        """
         repo_script = self.examples_dir / "repository" / "repo"
-        self.server = subprocess.Popen(
-            [sys.executable, "-u", str(repo_script), "-p", str(self.port)],
-            env=self.env,
-            cwd=self.test_dir,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
-        self.addCleanup(self._stop_server)
+        for attempt in range(_MAX_SERVER_STARTS):
+            self.port = _get_free_port()
+            self.base_url = f"http://{utils.TEST_HOST_ADDRESS}:{self.port}"
 
-        utils.wait_for_server(
-            utils.TEST_HOST_ADDRESS, "repository example", self.port
-        )
-        # wait_for_server only confirms the port is open; also wait until the
-        # repository has published its initial root metadata.
-        self._wait_for_root()
+            self._stopped_output = None
+            self.server = subprocess.Popen(
+                [sys.executable, "-u", str(repo_script), "-p", str(self.port)],
+                env=self.env,
+                cwd=self.test_dir,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+
+            if self._wait_for_root():
+                # Tear the server down at the end of the test.
+                self.addCleanup(self._stop_server)
+                return
+
+            # The server never served root metadata. Stop it (which drains its
+            # output) before deciding whether to retry.
+            exited_early = self.server.poll() is not None
+            self._stop_server()
+            output = self._server_output()
+
+            # A lost race for the port shows up as a bind failure: retry on a
+            # fresh port rather than reporting a misleading connection timeout.
+            if (
+                exited_early
+                and "Address already in use" in output
+                and attempt + 1 < _MAX_SERVER_STARTS
+            ):
+                continue
+
+            reason = (
+                f"exited early with code {self.server.returncode}"
+                if exited_early
+                else "did not serve root metadata in time"
+            )
+            self.fail(f"repository example {reason}:\n{output}")
 
     def _rmtree(self, path: str) -> None:
         # shutil.rmtree wrapper registered with addCleanup.
@@ -111,32 +151,43 @@ class TestExamplesEnd2End(unittest.TestCase):
         except subprocess.TimeoutExpired:
             self.server.kill()
             self.server.wait()
+        # Stash any remaining output before closing the pipe so it stays
+        # available to _server_output() after the server has been stopped.
         if self.server.stdout is not None:
+            self._stopped_output = self.server.stdout.read().decode(
+                "utf-8", errors="replace"
+            )
             self.server.stdout.close()
 
-    def _wait_for_root(self, timeout: int = 10) -> None:
-        """Poll until the server serves 1.root.json (or time out)."""
+    def _wait_for_root(self, timeout: int = 10) -> bool:
+        """Poll until the server serves 1.root.json.
+
+        Returns True once the server answers with the initial root metadata.
+        Returns False if the server process exits before then (so the caller
+        can retry on a new port) or if the timeout is reached without the
+        server ever exiting (a genuine readiness failure).
+        """
         deadline = time.monotonic() + timeout
         url = f"{self.base_url}/{_METADATA_URL}/1.root.json"
-        last_error: Exception | None = None
         while time.monotonic() < deadline:
             if self.server.poll() is not None:
-                self.fail(
-                    "repository example exited early with code "
-                    f"{self.server.returncode}:\n{self._server_output()}"
-                )
+                # Server exited; let the caller inspect its output.
+                return False
             try:
                 response = urllib3.request("GET", url)
                 if response.status == 200:
-                    return
-            except urllib3.exceptions.HTTPError as e:
-                last_error = e
+                    return True
+            except urllib3.exceptions.HTTPError:
+                # Connection refused/reset while the server is still starting.
+                pass
             time.sleep(0.05)
-        self.fail(
-            f"repository example never served root metadata: {last_error}"
-        )
+        return False
 
     def _server_output(self) -> str:
+        # If the server has been stopped, _stop_server() already drained the
+        # pipe; otherwise read whatever it has produced so far.
+        if self._stopped_output is not None:
+            return self._stopped_output
         if self.server.stdout is None:
             return ""
         return self.server.stdout.read().decode("utf-8", errors="replace")


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

This adds an end-to-end test that runs the `repository`, `uploader` and `client` examples against each other, which is the part of #2228 that was not covered by the `tuf.repository` interface tests already merged in #2651.

The new `tests/test_examples_e2e.py` drives the three examples the way a user runs them from the command line (see their READMEs):

* `examples/repository/repo` is started as a live HTTP server on a free port
* `examples/uploader/uploader` does Trust-On-First-Use, claims a delegation, and uploads target files to that server
* `examples/client/client` does Trust-On-First-Use and downloads the uploaded targets

Because the client downloads through `ngclient.Updater`, a successful download means the metadata chain and the target hash both verified, so the test asserts the downloaded content matches what the uploader published.

It also covers the "client that has metadata version N can successfully update to N+M" case from the issue: after the client is initialized and has downloaded a first target, the uploader adds a second target (which publishes new targets, snapshot and timestamp metadata). The test checks that the snapshot version advanced and that the already-initialized client can then refresh and download the new target.

A few notes on how it stays deterministic and isolated:

* the example scripts import their private helper modules by name (`from _simplerepo import SimpleRepository`), so each example dir is put on `PYTHONPATH`
* the client and uploader store trusted metadata and keys under `Path.home()`, so `HOME` is pointed at a temporary directory; nothing touches the real home dir and every run starts from a clean repository
* readiness is handled by polling for `1.root.json` (reusing `tests.utils.wait_for_server` for the port) rather than sleeping

The examples themselves are not modified; this only wires the existing ones together as a test. Ran locally with `python -m unittest tests.test_examples_e2e` (also green under the project's surrounding example tests), and `ruff check` / `ruff format` / `mypy` are clean on the new file.

I kept this scoped to the examples e2e slice. Whether the remaining idea in the issue (unit-testing `SimpleRepository` directly) is still wanted, and whether #2228 should stay open for it, is up to you.

Addresses #2228

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
