### PR TITLE
ngclient: propagate non-timeout urllib3 connection errors

### DIFF
--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -137,6 +137,25 @@ class TestFetcher(unittest.TestCase):
             self.fetcher.fetch(self.url)
         mock_session_get.assert_called_once()
 
+    # A non-timeout connection failure (e.g. TLS error) must surface as the
+    # original error, not be masked by an UnboundLocalError on "response".
+    @patch.object(
+        urllib3.PoolManager,
+        "request",
+        side_effect=urllib3.exceptions.MaxRetryError(
+            urllib3.connectionpool.ConnectionPool("localhost"),
+            "",
+            urllib3.exceptions.SSLError("certificate verify failed"),
+        ),
+    )
+    def test_session_get_ssl_error(self, mock_session_get: Mock) -> None:
+        with self.assertRaises(exceptions.DownloadError) as cm:
+            self.fetcher.fetch(self.url)
+        mock_session_get.assert_called_once()
+        self.assertIsInstance(
+            cm.exception.__cause__, urllib3.exceptions.MaxRetryError
+        )
+
     # Simple bytes download
     def test_download_bytes(self) -> None:
         data = self.fetcher.download_bytes(self.url, self.file_length)

--- a/tuf/ngclient/urllib3_fetcher.py
+++ b/tuf/ngclient/urllib3_fetcher.py
@@ -82,6 +82,9 @@ class Urllib3Fetcher(FetcherInterface):
         except urllib3.exceptions.MaxRetryError as e:
             if isinstance(e.reason, urllib3.exceptions.TimeoutError):
                 raise exceptions.SlowRetrievalError from e
+            # Any other reason (e.g. TLS or connection error): let the original
+            # error propagate instead of falling through to an unbound response.
+            raise
 
         if response.status >= 400:
             response.close()


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

While reading the Urllib3Fetcher I noticed that `_fetch()` only handles the timeout case of `MaxRetryError`. When the reason is anything else (a TLS certificate error, for instance) the except block does not re-raise, so execution continues to the `response.status` check while `response` is still unbound. The caller then gets an `UnboundLocalError` about `response` instead of the actual connection error, which makes real failures hard to diagnose.

This re-raises the original error when the reason is not a timeout, so `fetch()` wraps the meaningful error in a `DownloadError` as documented in FetcherInterface. I added a regression test that drives a non-timeout MaxRetryError and checks the underlying cause is preserved. The full test suite passes locally with tox.

Fixes: non-timeout connection errors surfacing as UnboundLocalError