### PR TITLE
Fix Role and DelegatedRole hashing

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,6 +34,7 @@ from tuf.api.metadata import (
     Delegations,
     Metadata,
     MetaFile,
+    Role,
     Root,
     RootVerificationResult,
     Signature,
@@ -1081,6 +1082,34 @@ class TestMetadata(unittest.TestCase):
             role = DelegatedRole("", [], 1, False, None, hash_prefixes)
             self.assertFalse(role.is_delegated_path("a/non-matching path"))
             self.assertTrue(role.is_delegated_path("a/path"))
+
+    def test_role_and_delegated_role_hash(self) -> None:
+        # Role.__hash__ previously tried to hash self.keyids (a list) and
+        # self.unrecognized_fields (a dict), both unhashable, so hash()
+        # crashed with TypeError for every Role subclass.
+        role = Role(["keyid1", "keyid2"], 1)
+        self.assertIsInstance(hash(role), int)
+
+        # equal objects must produce equal hashes (Python data model)
+        role2 = Role(["keyid1", "keyid2"], 1)
+        self.assertEqual(role, role2)
+        self.assertEqual(hash(role), hash(role2))
+
+        # DelegatedRole.__hash__ also referenced a non-existent 'path'
+        # attribute (the real attribute is 'paths'); verify it's hashable
+        # with both paths and path_hash_prefixes variants.
+        dr = DelegatedRole("role1", [], 1, False, ["*"], None)
+        self.assertIsInstance(hash(dr), int)
+        dr2 = DelegatedRole("role1", [], 1, False, ["*"], None)
+        self.assertEqual(dr, dr2)
+        self.assertEqual(hash(dr), hash(dr2))
+
+        dr_prefix = DelegatedRole("role2", [], 1, False, None, ["abc"])
+        self.assertIsInstance(hash(dr_prefix), int)
+
+        # a DelegatedRole must now actually work as a set member / dict key
+        role_set = {dr, dr2}
+        self.assertEqual(len(role_set), 1)
 
     def test_is_delegated_role_in_succinct_roles(self) -> None:
         succinct_roles = SuccinctRoles([], 1, 5, "bin")

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -311,7 +311,7 @@ class Role:
         )
 
     def __hash__(self) -> int:
-        return hash((self.keyids, self.threshold, self.unrecognized_fields))
+        return hash((tuple(self.keyids), self.threshold))
 
     @classmethod
     def from_dict(cls, role_dict: dict[str, Any]) -> Role:
@@ -1131,13 +1131,19 @@ class DelegatedRole(Role):
         )
 
     def __hash__(self) -> int:
+        paths = tuple(self.paths) if self.paths is not None else None
+        prefixes = (
+            tuple(self.path_hash_prefixes)
+            if self.path_hash_prefixes is not None
+            else None
+        )
         return hash(
             (
                 super().__hash__(),
                 self.name,
                 self.terminating,
-                self.path,
-                self.path_hash_prefixes,
+                paths,
+                prefixes,
             )
         )
 


### PR DESCRIPTION
## Description

While going through `_payload.py`, I noticed that `Role.__hash__()` fails because it tries to hash `keyids` (a list) and `unrecognized_fields` (a dict) directly.

This PR:

* Converts `keyids` to a tuple before hashing.
* Excludes `unrecognized_fields` since it may contain nested, unhashable JSON.
* Fixes `DelegatedRole.__hash__()` using `self.path` instead of `self.paths`.
* Converts `paths` and `path_hash_prefixes` to tuples before hashing.
* Adds regression tests for hashing, equality, and set usage.

The full test suite passes locally with `tox`.

I noticed similar patterns in a few other metadata classes, but kept this PR focused on `Role` and `DelegatedRole`.