### PR TITLE
docs: add Windows note for python3 command

### DIFF
--- a/docs/INSTALLATION.rst
+++ b/docs/INSTALLATION.rst
@@ -5,6 +5,11 @@ All versions of ``python-tuf`` can be installed from
 `PyPI <https://pypi.org/project/tuf/>`_ with
 `pip <https://pip.pypa.io/en/stable/>`_.
 
+.. note::
+
+   Windows users: replace ``python3`` with ``python`` or use the
+   ``py`` launcher (e.g. ``py -m pip install tuf``).
+
 ::
 
    python3 -m pip install tuf


### PR DESCRIPTION
On a standard Windows Python.org installation, python3 is not
available — only python is. This causes confusion when users
follow the installation commands in INSTALLATION.rst.

Add a note at the top of the Installation section informing
Windows users to use python or the py launcher instead.

