### PR TITLE
updates urllib3 dependency specifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 ]
 dependencies = [
   "securesystemslib~=1.0",
-  "urllib3<3,>=1.21.1",
+  "urllib3~=2.0",
 ]
 dynamic = ["version"]
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -7,4 +7,4 @@
 # triggers CI/CD builds to automatically test against updated dependencies.
 #
 securesystemslib[crypto]
-urllib3
+urllib3~=2.0


### PR DESCRIPTION
This PR updates the project's urllib3 dependency specifier. Previously, tuf's metadata claimed that urllib3 version 1.21.1+ was supported, but actually, tuf v6.0.0 requires urllib3 version 2+

Fixes #2989

