### PR TITLE
ngclient: add download_target_bytes()

### DIFF
--- a/tests/test_updater_fetch_target.py
+++ b/tests/test_updater_fetch_target.py
@@ -119,6 +119,51 @@ class TestFetchTarget(unittest.TestCase):
         self.assertEqual(path, updater.find_cached_target(info))
         self.assertEqual(path, updater.find_cached_target(info, path))
 
+    @utils.run_sub_tests_with_dataset(targets)
+    def test_fetch_target_bytes(self, target: TestTarget) -> None:
+        path = os.path.join(self.targets_dir, target.encoded_path)
+
+        # Add target to repository
+        self.sim.targets.version += 1
+        self.sim.add_target("targets", target.content, target.path)
+        self.sim.update_snapshot()
+
+        updater = self._init_updater()
+        info = updater.get_targetinfo(target.path)
+        assert info is not None
+
+        # download_target_bytes returns the verified content
+        self.assertEqual(target.content, updater.download_target_bytes(info))
+
+        # ...and does not touch the local cache
+        self.assertFalse(os.path.exists(path))
+        self.assertIsNone(updater.find_cached_target(info))
+
+    def test_invalid_target_download_bytes(self) -> None:
+        target = TestTarget("targetpath", b"content", "targetpath")
+
+        # Add target to repository
+        self.sim.targets.version += 1
+        self.sim.add_target("targets", target.content, target.path)
+        self.sim.update_snapshot()
+
+        updater = self._init_updater()
+        info = updater.get_targetinfo(target.path)
+        assert info is not None
+
+        # Corrupt the file content to not match the hash
+        self.sim.target_files[target.path].data = b"conten@"
+        with self.assertRaises(RepositoryError):
+            updater.download_target_bytes(info)
+
+        # Corrupt the file content to not match the length
+        self.sim.target_files[target.path].data = b"cont"
+        with self.assertRaises(RepositoryError):
+            updater.download_target_bytes(info)
+
+        # Verify nothing is persisted in cache
+        self.assertIsNone(updater.find_cached_target(info))
+
     def test_download_targets_with_succinct_roles(self) -> None:
         self.sim.add_succinct_roles("targets", 8, "bin")
         self.sim.update_snapshot()

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -275,6 +275,67 @@ class Updater:
             filepath = self._generate_target_file_path(targetinfo)
         Path(filepath).parent.mkdir(exist_ok=True, parents=True)
 
+        full_url = self._target_file_url(targetinfo, target_base_url)
+
+        with self._fetcher.download_file(
+            full_url, targetinfo.length
+        ) as target_file:
+            targetinfo.verify_length_and_hashes(target_file)
+
+            target_file.seek(0)
+            with open(filepath, "wb") as destination_file:
+                shutil.copyfileobj(target_file, destination_file)
+
+        logger.debug("Downloaded target %s", targetinfo.path)
+        return filepath
+
+    def download_target_bytes(
+        self,
+        targetinfo: TargetFile,
+        target_base_url: str | None = None,
+    ) -> bytes:
+        """Download the target file specified by ``targetinfo`` as bytes.
+
+        This is like ``download_target()`` but returns the verified target
+        content instead of writing it into the local cache. The local target
+        cache is neither read nor written, so ``find_cached_target()`` is not
+        consulted: use ``download_target()`` if caching is wanted.
+
+        The whole target is buffered in memory (the content cannot be verified
+        until it has been downloaded in full), so this is not suitable for very
+        large targets.
+
+        Args:
+            targetinfo: ``TargetFile`` from ``get_targetinfo()``.
+            target_base_url: Base URL used to form the final target
+                download URL. Default is the value provided in ``Updater()``
+
+        Raises:
+            ValueError: Invalid arguments
+            DownloadError: Download of the target file failed in some way
+            RepositoryError: Downloaded target failed to be verified in some way
+
+        Returns:
+            Verified target file content
+        """
+
+        full_url = self._target_file_url(targetinfo, target_base_url)
+
+        with self._fetcher.download_file(
+            full_url, targetinfo.length
+        ) as target_file:
+            targetinfo.verify_length_and_hashes(target_file)
+
+            target_file.seek(0)
+            data: bytes = target_file.read()
+
+        logger.debug("Downloaded target %s", targetinfo.path)
+        return data
+
+    def _target_file_url(
+        self, targetinfo: TargetFile, target_base_url: str | None
+    ) -> str:
+        """Build the remote download URL for a target file."""
         if target_base_url is None:
             if self._target_base_url is None:
                 raise ValueError(
@@ -292,19 +353,7 @@ class Updater:
             hashes = list(targetinfo.hashes.values())
             dirname, sep, basename = target_filepath.rpartition("/")
             target_filepath = f"{dirname}{sep}{hashes[0]}.{basename}"
-        full_url = f"{target_base_url}{target_filepath}"
-
-        with self._fetcher.download_file(
-            full_url, targetinfo.length
-        ) as target_file:
-            targetinfo.verify_length_and_hashes(target_file)
-
-            target_file.seek(0)
-            with open(filepath, "wb") as destination_file:
-                shutil.copyfileobj(target_file, destination_file)
-
-        logger.debug("Downloaded target %s", targetinfo.path)
-        return filepath
+        return f"{target_base_url}{target_filepath}"
 
     def _download_metadata(
         self, rolename: str, length: int, version: int | None = None


### PR DESCRIPTION
Adds `Updater.download_target_bytes()`, which downloads and verifies a target and hands back the content as `bytes` instead of writing it to the cache dir, so callers like sigstore-python that just want the verified bytes in memory don't have to round-trip through a file.

The verification path is shared, not duplicated: I pulled the URL-building out of `download_target()` into a small `_target_file_url()` helper, and both methods then do the same `_fetcher.download_file()` + `targetinfo.verify_length_and_hashes()` against the same downloaded stream. The only difference is what happens after verification succeeds - `download_target()` copies to disk, `download_target_bytes()` reads the stream and returns it. So the length/hash checks are byte-for-byte identical between the two.

On the cache-timing concern from #1556 (re #1168): the new method deliberately does not touch the local target cache at all. It doesn't call `find_cached_target()`, doesn't read an existing cached file, and doesn't persist anything. Since it never consults the cache, there's no cache-hit/miss timing to leak - it always downloads and verifies. Callers who want caching keep using `download_target()` + `find_cached_target()`.

One thing worth flagging: because a target's hash can't be checked until it's fully downloaded, the bytes variant buffers the whole target in memory. That's fine for the small artifacts this is aimed at, but it's not suitable for very large targets - I noted that in the docstring. The streaming/iterator idea from the issue thread would be a separate, larger API and I left it out here.

Tests in `tests/test_updater_fetch_target.py`, mirroring the existing `download_target` tests against the repository simulator:
- `test_fetch_target_bytes` (dataset-driven, same three target cases): returned bytes match expected content, and nothing gets written to the cache dir (`find_cached_target` stays `None`).
- `test_invalid_target_download_bytes`: hash mismatch and length mismatch both still raise `RepositoryError`, and nothing is persisted.

`tox`-equivalent locally: `pytest tests/test_updater_*.py` green (updater suites 27 passed / 13 subtests), `black`/`isort` clean at line-length 80, `mypy` clean on `updater.py`, `pylint` 9.91 (only pre-existing `__init__` arg-count warnings, untouched by this change).

Fixes #1556
