### PR TITLE
ngclient: raise SlowRetrievalError on mid-stream read timeout

### DIFF
--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -122,6 +122,46 @@ class TestFetcher(unittest.TestCase):
             next(self.fetcher.fetch(self.url))
         mock_response.stream.assert_called_once()
 
+    # urllib3 raises ReadTimeoutError directly when the gap timeout expires
+    # mid-stream: it is a TimeoutError but not a MaxRetryError, so it is not
+    # covered by the MaxRetryError case above.
+    @patch.object(urllib3.PoolManager, "request")
+    def test_response_read_timeout_error(self, mock_session_get: Mock) -> None:
+        mock_response = Mock()
+        mock_response.status = 200
+        attr = {
+            "stream.side_effect": urllib3.exceptions.ReadTimeoutError(
+                urllib3.connectionpool.ConnectionPool("localhost"),
+                "",
+                "Read timed out.",
+            )
+        }
+        mock_response.configure_mock(**attr)
+        mock_session_get.return_value = mock_response
+
+        with self.assertRaises(exceptions.SlowRetrievalError):
+            next(self.fetcher.fetch(self.url))
+        mock_response.stream.assert_called_once()
+
+    # The public download_* API documents DownloadError: a mid-stream timeout
+    # must not escape as a raw urllib3 error.
+    @patch.object(urllib3.PoolManager, "request")
+    def test_download_bytes_read_timeout(self, mock_session_get: Mock) -> None:
+        mock_response = Mock()
+        mock_response.status = 200
+        attr = {
+            "stream.side_effect": urllib3.exceptions.ReadTimeoutError(
+                urllib3.connectionpool.ConnectionPool("localhost"),
+                "",
+                "Read timed out.",
+            )
+        }
+        mock_response.configure_mock(**attr)
+        mock_session_get.return_value = mock_response
+
+        with self.assertRaises(exceptions.SlowRetrievalError):
+            self.fetcher.download_bytes(self.url, self.file_length)
+
     # Read/connect session timeout error
     @patch.object(
         urllib3.PoolManager,

--- a/tuf/ngclient/urllib3_fetcher.py
+++ b/tuf/ngclient/urllib3_fetcher.py
@@ -106,9 +106,16 @@ class Urllib3Fetcher(FetcherInterface):
 
         try:
             yield from response.stream(self.chunk_size)
+        except urllib3.exceptions.TimeoutError as e:
+            # Raised directly when the gap timeout expires mid-stream:
+            # ReadTimeoutError is a TimeoutError but not a MaxRetryError.
+            raise exceptions.SlowRetrievalError from e
         except urllib3.exceptions.MaxRetryError as e:
             if isinstance(e.reason, urllib3.exceptions.TimeoutError):
                 raise exceptions.SlowRetrievalError from e
+            # Any other reason: propagate rather than ending the stream
+            # silently, which would look like a complete download.
+            raise
 
         finally:
             response.release_conn()


### PR DESCRIPTION
`Urllib3Fetcher._chunks` only converts a `MaxRetryError` into `SlowRetrievalError`. When
the gap timeout expires part way through a response body, urllib3 raises
`ReadTimeoutError` directly, and that is a `TimeoutError` but not a `MaxRetryError`, so it
escapes untouched.

That reaches the public API. `fetch()` wraps `self._fetch(url)`, but `_fetch` only builds
the generator, so the wrapper covers connection setup and not streaming. `download_file()`
then iterates the generator outside any try, so a raw urllib3 error comes out of
`download_bytes()` and `download_file()`, both of which document `DownloadError`.

Against a local server that sends headers plus ten bytes and then stalls, with
`socket_timeout=1`:

```
Urllib3Fetcher   -> LEAKED urllib3.exceptions.ReadTimeoutError
RequestsFetcher  -> SlowRetrievalError   (documented)
```

`RequestsFetcher._chunks` catches `requests.exceptions.Timeout` and gets this right, so
the two bundled fetchers disagree on the same condition, and the default one is the one
that leaks.

The existing `test_response_read_timeout` passes because it mocks
`stream.side_effect` as a `MaxRetryError` wrapping a `TimeoutError`, which is not what
urllib3 raises here. I left that test alone and added the `ReadTimeoutError` case
alongside it, plus one through `download_bytes()` so the public contract is pinned rather
than just the generator.

One extra line worth flagging: the existing `MaxRetryError` branch falls through without
re-raising when the reason is not a timeout, which ends the generator silently and looks
like a complete download to `download_file()`. I have made that propagate. I could not
construct a case that triggers it, so treat it as tidying rather than a reported bug, and
say the word if you would rather it came out of this PR.

After the change both fetchers raise `SlowRetrievalError` against the stalling server.
Full suite is 202 passed, and `ruff check`, `ruff format --diff` and `mypy` are clean.
