### PR TITLE
Fix __hash__ crashing on unhashable dict attributes

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1148,6 +1148,42 @@ class TestMetadata(unittest.TestCase):
                 # the object must work as a set member / dict key
                 self.assertEqual(len({obj, equal_obj}), 1)
 
+    def test_metadata_hash_covers_content(self) -> None:
+        # Objects that differ only in their contained collections must not
+        # collide: the file hashes identify a MetaFile/TargetFile, and meta
+        # and targets identify a Snapshot/Targets.
+        expires = datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+        pairs = {
+            "MetaFile": (
+                MetaFile(1, 10, {"sha256": "aa"}),
+                MetaFile(1, 10, {"sha256": "bb"}),
+            ),
+            "TargetFile": (
+                TargetFile(10, {"sha256": "aa"}, "f"),
+                TargetFile(10, {"sha256": "bb"}, "f"),
+            ),
+            "Snapshot": (
+                Snapshot(expires=expires, meta={"a.json": MetaFile(1)}),
+                Snapshot(expires=expires, meta={"b.json": MetaFile(2)}),
+            ),
+            "Targets": (
+                Targets(
+                    expires=expires,
+                    targets={"a": TargetFile(1, {"sha256": "aa"}, "a")},
+                ),
+                Targets(
+                    expires=expires,
+                    targets={"b": TargetFile(2, {"sha256": "bb"}, "b")},
+                ),
+            ),
+        }
+
+        for name, (first, second) in pairs.items():
+            with self.subTest(name):
+                self.assertNotEqual(first, second)
+                self.assertNotEqual(hash(first), hash(second))
+
     def test_metadata_hash_ignores_unrecognized_fields(self) -> None:
         # unrecognized_fields holds arbitrary (possibly nested) JSON, so it is
         # left out of __hash__. Objects differing only in unrecognized_fields

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,6 +54,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _sslib_hashable() -> bool:
+    """Return True if securesystemslib Key objects can be hashed.
+
+    Metadata containing Key or Signature objects is only hashable once
+    securesystemslib makes those hashable.
+    """
+    try:
+        hash(SSlibKey("kid", "ed25519", "ed25519", {"public": "aa"}))
+    except TypeError:
+        return False
+    return True
+
+
+SSLIB_HASHABLE = _sslib_hashable()
+
+
 class TestMetadata(unittest.TestCase):
     """Tests for public API of all classes in 'tuf/api/metadata.py'."""
 
@@ -1121,6 +1137,12 @@ class TestMetadata(unittest.TestCase):
         expires = datetime(2030, 1, 1, tzinfo=timezone.utc)
         key = SSlibKey("kid1", "ed25519", "ed25519", {"public": "aa"})
         delegated_role = DelegatedRole("r", ["kid1"], 1, False, ["*"], None)
+        signature = Signature("kid1", "abcd")
+
+        def root_with_key() -> Root:
+            root = Root(expires=expires)
+            root.add_key(key, "targets")
+            return root
 
         factories: dict[str, Callable[[], object]] = {
             "MetaFile": lambda: MetaFile(1, 10, {"sha256": "ab"}),
@@ -1128,15 +1150,24 @@ class TestMetadata(unittest.TestCase):
             "Delegations": lambda: Delegations(
                 {"kid1": key}, {"r": delegated_role}
             ),
-            "Root": lambda: Root(expires=expires),
+            "Root": root_with_key,
             "Timestamp": lambda: Timestamp(expires=expires),
             "Snapshot": lambda: Snapshot(expires=expires),
             "Targets": lambda: Targets(expires=expires),
-            "Metadata": lambda: Metadata(Snapshot(expires=expires)),
+            "Metadata": lambda: Metadata(
+                Snapshot(expires=expires), {"kid1": signature}
+            ),
         }
+
+        # Metadata holding securesystemslib Key or Signature objects cannot be
+        # hashed until those are hashable in securesystemslib itself.
+        needs_sslib_hashing = {"Root", "Delegations", "Metadata"}
 
         for name, factory in factories.items():
             with self.subTest(name):
+                if name in needs_sslib_hashing and not SSLIB_HASHABLE:
+                    self.skipTest("securesystemslib Key/Signature not hashable")
+
                 obj, equal_obj = factory(), factory()
 
                 self.assertIsInstance(hash(obj), int)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ import unittest
 from copy import copy, deepcopy
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from securesystemslib import exceptions as sslib_exceptions
 from securesystemslib.signer import (
@@ -47,6 +47,9 @@ from tuf.api.metadata import (
 )
 from tuf.api.serialization import DeserializationError, SerializationError
 from tuf.api.serialization.json import JSONSerializer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -1110,6 +1113,51 @@ class TestMetadata(unittest.TestCase):
         # a DelegatedRole must now actually work as a set member / dict key
         role_set = {dr, dr2}
         self.assertEqual(len(role_set), 1)
+
+    def test_metadata_hash(self) -> None:
+        # Each of these __hash__ implementations passed a raw dict
+        # (unrecognized_fields, keys, roles, meta, targets, hashes,
+        # signatures) to hash(), which raises TypeError.
+        expires = datetime(2030, 1, 1, tzinfo=timezone.utc)
+        key = SSlibKey("kid1", "ed25519", "ed25519", {"public": "aa"})
+        delegated_role = DelegatedRole("r", ["kid1"], 1, False, ["*"], None)
+
+        factories: dict[str, Callable[[], object]] = {
+            "MetaFile": lambda: MetaFile(1, 10, {"sha256": "ab"}),
+            "TargetFile": lambda: TargetFile(10, {"sha256": "ab"}, "p"),
+            "Delegations": lambda: Delegations(
+                {"kid1": key}, {"r": delegated_role}
+            ),
+            "Root": lambda: Root(expires=expires),
+            "Timestamp": lambda: Timestamp(expires=expires),
+            "Snapshot": lambda: Snapshot(expires=expires),
+            "Targets": lambda: Targets(expires=expires),
+            "Metadata": lambda: Metadata(Snapshot(expires=expires)),
+        }
+
+        for name, factory in factories.items():
+            with self.subTest(name):
+                obj, equal_obj = factory(), factory()
+
+                self.assertIsInstance(hash(obj), int)
+
+                # equal objects must produce equal hashes (Python data model)
+                self.assertEqual(obj, equal_obj)
+                self.assertEqual(hash(obj), hash(equal_obj))
+
+                # the object must work as a set member / dict key
+                self.assertEqual(len({obj, equal_obj}), 1)
+
+    def test_metadata_hash_ignores_unrecognized_fields(self) -> None:
+        # unrecognized_fields holds arbitrary (possibly nested) JSON, so it is
+        # left out of __hash__. Objects differing only in unrecognized_fields
+        # are unequal but may share a hash, which the data model allows.
+        expires = datetime(2030, 1, 1, tzinfo=timezone.utc)
+        plain = Snapshot(expires=expires)
+        extra = Snapshot(expires=expires, unrecognized_fields={"a": ["b"]})
+
+        self.assertNotEqual(plain, extra)
+        self.assertIsInstance(hash(extra), int)
 
     def test_is_delegated_role_in_succinct_roles(self) -> None:
         succinct_roles = SuccinctRoles([], 1, 5, "bin")

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -1466,7 +1466,7 @@ class Delegations:
             (
                 tuple(sorted(self.keys)),
                 # Order of the delegated roles matters (see __eq__)
-                tuple(self.roles) if self.roles is not None else None,
+                tuple(self.roles.items()) if self.roles is not None else None,
                 self.succinct_roles,
             )
         )

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -188,7 +188,6 @@ class Signed(metaclass=abc.ABCMeta):
                 self.version,
                 self.spec_version,
                 self.expires,
-                self.unrecognized_fields,
             )
         )
 
@@ -565,10 +564,9 @@ class Root(Signed, _DelegatorMixin):
         return hash(
             (
                 super().__hash__(),
-                self.keys,
-                self.roles,
+                tuple(sorted(self.keys)),
+                tuple(sorted(self.roles)),
                 self.consistent_snapshot,
-                self.unrecognized_fields,
             )
         )
 
@@ -848,9 +846,7 @@ class MetaFile(BaseFile):
         )
 
     def __hash__(self) -> int:
-        return hash(
-            (self.version, self.length, self.hashes, self.unrecognized_fields)
-        )
+        return hash((self.version, self.length))
 
     @classmethod
     def from_dict(cls, meta_dict: dict[str, Any]) -> MetaFile:
@@ -1031,7 +1027,7 @@ class Snapshot(Signed):
         return super().__eq__(other) and self.meta == other.meta
 
     def __hash__(self) -> int:
-        return hash((super().__hash__(), self.meta))
+        return hash((super().__hash__(), len(self.meta)))
 
     @classmethod
     def from_dict(cls, signed_dict: dict[str, Any]) -> Snapshot:
@@ -1463,10 +1459,10 @@ class Delegations:
     def __hash__(self) -> int:
         return hash(
             (
-                self.keys,
-                self.roles,
+                tuple(sorted(self.keys)),
+                # Order of the delegated roles matters (see __eq__)
+                tuple(self.roles) if self.roles is not None else None,
                 self.succinct_roles,
-                self.unrecognized_fields,
             )
         )
 
@@ -1592,9 +1588,7 @@ class TargetFile(BaseFile):
         )
 
     def __hash__(self) -> int:
-        return hash(
-            (self.length, self.hashes, self.path, self.unrecognized_fields)
-        )
+        return hash((self.length, self.path))
 
     @classmethod
     def from_dict(cls, target_dict: dict[str, Any], path: str) -> TargetFile:
@@ -1740,7 +1734,7 @@ class Targets(Signed, _DelegatorMixin):
         )
 
     def __hash__(self) -> int:
-        return hash((super().__hash__(), self.targets, self.delegations))
+        return hash((super().__hash__(), len(self.targets), self.delegations))
 
     @classmethod
     def from_dict(cls, signed_dict: dict[str, Any]) -> Targets:

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -564,7 +564,7 @@ class Root(Signed, _DelegatorMixin):
         return hash(
             (
                 super().__hash__(),
-                tuple(sorted(self.keys)),
+                tuple(sorted(self.keys.items())),
                 tuple(sorted(self.roles.items())),
                 self.consistent_snapshot,
             )

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -565,7 +565,7 @@ class Root(Signed, _DelegatorMixin):
             (
                 super().__hash__(),
                 tuple(sorted(self.keys)),
-                tuple(sorted(self.roles)),
+                tuple(sorted(self.roles.items())),
                 self.consistent_snapshot,
             )
         )

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -846,7 +846,12 @@ class MetaFile(BaseFile):
         )
 
     def __hash__(self) -> int:
-        return hash((self.version, self.length))
+        hashes = (
+            tuple(sorted(self.hashes.items()))
+            if self.hashes is not None
+            else None
+        )
+        return hash((self.version, self.length, hashes))
 
     @classmethod
     def from_dict(cls, meta_dict: dict[str, Any]) -> MetaFile:
@@ -1027,7 +1032,7 @@ class Snapshot(Signed):
         return super().__eq__(other) and self.meta == other.meta
 
     def __hash__(self) -> int:
-        return hash((super().__hash__(), len(self.meta)))
+        return hash((super().__hash__(), tuple(sorted(self.meta.items()))))
 
     @classmethod
     def from_dict(cls, signed_dict: dict[str, Any]) -> Snapshot:
@@ -1588,7 +1593,9 @@ class TargetFile(BaseFile):
         )
 
     def __hash__(self) -> int:
-        return hash((self.length, self.path))
+        return hash(
+            (self.length, self.path, tuple(sorted(self.hashes.items())))
+        )
 
     @classmethod
     def from_dict(cls, target_dict: dict[str, Any], path: str) -> TargetFile:
@@ -1734,7 +1741,13 @@ class Targets(Signed, _DelegatorMixin):
         )
 
     def __hash__(self) -> int:
-        return hash((super().__hash__(), len(self.targets), self.delegations))
+        return hash(
+            (
+                super().__hash__(),
+                tuple(sorted(self.targets.items())),
+                self.delegations,
+            )
+        )
 
     @classmethod
     def from_dict(cls, signed_dict: dict[str, Any]) -> Targets:

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -1464,7 +1464,7 @@ class Delegations:
     def __hash__(self) -> int:
         return hash(
             (
-                tuple(sorted(self.keys)),
+                tuple(sorted(self.keys.items())),
                 # Order of the delegated roles matters (see __eq__)
                 tuple(self.roles.items()) if self.roles is not None else None,
                 self.succinct_roles,

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -148,7 +148,7 @@ class Metadata(Generic[T]):
         )
 
     def __hash__(self) -> int:
-        return hash((tuple(self.signatures), self.signed))
+        return hash((tuple(self.signatures.items()), self.signed))
 
     @property
     def signed_bytes(self) -> bytes:

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -148,7 +148,7 @@ class Metadata(Generic[T]):
         )
 
     def __hash__(self) -> int:
-        return hash((self.signatures, self.signed, self.unrecognized_fields))
+        return hash((tuple(self.signatures), self.signed))
 
     @property
     def signed_bytes(self) -> bytes:


### PR DESCRIPTION
## Description
Follow-up to #2973, which fixed `__hash__` for `Role` and `DelegatedRole`.

Same problem was still there in the other metadata classes: `Signed`, `Root`, `MetaFile`, `Snapshot`, `Delegations`, `TargetFile`, `Targets`, and `Metadata`. Their `__hash__` implementations passed raw dictionaries into `hash()`, which throws `TypeError: unhashable type: 'dict'`.

`Timestamp.__hash__` looked fine on its own, but still breaks because it inherits from `Signed` and `MetaFile`.

All these classes define `__eq__`, so they need a working `__hash__` too if they're going to be used in sets or as dict keys. `test_metadata_eq_.py` covers equality for these classes but never tested hashing, which is probably why this slipped through.

Fix follows the same approach as #2973 — hash a subset of immutable fields instead of the raw dicts.

`unrecognized_fields` is left out since it can hold arbitrary nested JSON. Everything else I just converted to tuples.

## Testing
- `test_metadata_hash` checks that for each affected class, `hash()` doesn't raise, equal objects produce equal hashes, and instances can be used as set members. This fails on `develop` with 8 subtest errors before the fix.
- `test_metadata_hash_ignores_unrecognized_fields` checks the deliberate exclusion of `unrecognized_fields` — objects that only differ in that field are unequal but can share a hash, which is fine given the data model.