### PR TITLE
Prepare release 7.0.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## v7.0.1
+
+### Fixed
+
+* Fix hash method on Role and DelegatedRole (#2973)
+* Fix incorrect dependency range for urllib3 (#2990)
+* ngclient: Fix connection exception handling (#2964, #2993)
+* ngclient: Fix incorrect delegation in diamond-shape case (#2978)
+* ngclient: Avoid use of symlink on Windows: it requires privileges (#2981)
+
 ## v7.0.0
 
 This is a major release only because of a minor ngclient API tweak: there

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -4,4 +4,4 @@
 """TUF."""
 
 # This value is used in the ngclient user agent.
-__version__ = "7.0.0"
+__version__ = "7.0.1"


### PR DESCRIPTION
Everything looks like a bug fix, bumping patch number only.
* Fix hash method on Role and DelegatedRole (#2973)
* Fix incorrect dependency range for urllib3 (#2990)
* ngclient: Fix connection exception handling (#2964, #2993)
* ngclient: Fix incorrect delegation in diamond-shape case (#2978)
* ngclient: Avoid use of symlink on Windows: it requires privileges (#2981)

Fixes #2985 


The hash-ability of our classes is still questionable (see discussion in #2995) but I don't think it's critical as they've never been hashable before.
