### PR TITLE
Add Table of Contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Python-TUF provides the following APIs:
 The reference implementation strives to be a readable guide and demonstration
 for those working on implementing TUF in their own languages, environments, or
 update systems.
+## Table of Contents
+
+- [About The Update Framework](#about-the-update-framework)
+- [Documentation](#documentation)
+- [Contact](#contact)
+- [Security Issues and Bugs](#security-issues-and-bugs)
+- [License](#license)
+- [Acknowledgements](#acknowledgements)
 
 
 About The Update Framework


### PR DESCRIPTION

**Description of the changes being introduced by the pull request**:

Adds a Table of Contents to the README for easier navigation, as suggested in #2654.

This is a small, focused change per @jku's feedback on the earlier PR (#2655) that README improvements should be split into minimal, single-purpose PRs rather than one large combined change. Happy to follow up with separate small PRs for other items from the list if this looks good.

This is a documentation-only change; no tests apply.

Addresses #2654 (partial - table of contents only)
