### PR TITLE
Fix is_expired docstring for reference_time

### DIFF
--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -252,8 +252,9 @@ class Signed(metaclass=abc.ABCMeta):
         """Check metadata expiration against a reference time.
 
         Args:
-            reference_time: Time to check expiration date against. A naive
-                datetime in UTC expected. Default is current UTC date and time.
+            reference_time: Time to check expiration date against. A
+                timezone-aware datetime is expected. Default is current UTC
+                date and time.
 
         Returns:
             ``True`` if expiration time is less than the reference time.


### PR DESCRIPTION
The `Signed.is_expired()` docstring says that `reference_time` should be a naive datetime, but passing a naive datetime raises:

 snapshot.is_expired(datetime(2026, 1, 1))
TypeError: can't compare offset-naive and offset-aware datetimes

`self.expires` is timezone-aware, and the default `datetime.now(timezone.utc)` is aware as well, so `reference_time` needs to be timezone-aware too.

This PR only updates the docstring and does not change the behaviour.

