### PR TITLE
ngclient: Update root.json link atomically

### DIFF
--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -385,6 +385,31 @@ class TestUpdater(unittest.TestCase):
         with open(linkname, "rb") as f1, open(target, "rb") as f2:
             self.assertEqual(f1.read(), f2.read())
 
+    @patch("os.link")
+    @patch("os.symlink")
+    def test_update_root_symlink_keeps_root_on_failure(
+        self, mock_symlink: MagicMock, mock_link: MagicMock
+    ) -> None:
+        """Cached root.json must survive a failed link update."""
+        linkname = os.path.join(self.updater._dir, "root.json")
+        with open(linkname, "rb") as f:
+            original = f.read()
+
+        err = OSError("no link for you")
+        mock_symlink.side_effect = err
+        mock_link.side_effect = err
+
+        with self.assertRaises(OSError):
+            self.updater._update_root_symlink()
+
+        # root.json is the trust anchor for bootstrap=None: losing it would
+        # leave the client unable to start
+        self.assertTrue(os.path.exists(linkname))
+        with open(linkname, "rb") as f:
+            self.assertEqual(f.read(), original)
+
+        self.assertFalse(os.path.exists(f"{linkname}.tmp"))
+
 
 if __name__ == "__main__":
     utils.configure_test_logging(sys.argv)

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -367,16 +367,23 @@ class Updater:
         linkname = os.path.join(self._dir, "root.json")
         version = self._trusted_set.root.version
         current = os.path.join("root_history", f"{version}.root.json")
-        with contextlib.suppress(FileNotFoundError):
-            os.remove(linkname)
+
+        temp_name = f"{linkname}.tmp"
         try:
-            os.symlink(current, linkname)
-        except OSError as e:
-            if getattr(e, "winerror", None) == 1314:
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(temp_name)
+            try:
+                os.symlink(current, temp_name)
+            except OSError as e:
+                if getattr(e, "winerror", None) != 1314:
+                    raise
                 # Fallback for NTFS "required privilege is not held by client"
-                os.link(os.path.join(self._dir, current), linkname)
-            else:
-                raise
+                os.link(os.path.join(self._dir, current), temp_name)
+            os.replace(temp_name, linkname)
+        except OSError:
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(temp_name)
+            raise
 
     def _load_root(self) -> None:
         """Load root metadata.


### PR DESCRIPTION
`_update_root_symlink()` deletes `root.json` before creating the new link, so if the process dies in that window or the link can't be created, `root.json` just stays gone:

```text
after failed update, root.json exists: False
bootstrap=None now fails: FileNotFoundError
```

Since that's the trust anchor for `Updater(bootstrap=None)`, the client can't start after that. It also runs from a `finally` block in `_load_root()`, so this can happen on failure paths too.

Fixed this by creating the link under a temp name and using `os.replace()` to put it in place, same idea as `_persist_file()`. I used a fixed `.tmp` name instead of `tempfile` since `os.symlink()` needs a path that doesn't exist yet, and multiple Updater instances aren't supported anyway.

Added a test that fails on develop.
